### PR TITLE
Feature/cross language serialization from master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 build/
 dist/
 *.egg-info
+
+venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cryptography==2.8
 requests==2.23.0
-vantage6-common
+PyJWT
+vantage6-common >= 1.0.0b13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cryptography==2.8
 requests==2.23.0
+vantage6-common

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,15 +20,19 @@ ORGANIZATION_IDS = [1]
 
 
 def test_post_task_legacy_method():
+    input_ = {'method': TASK_NAME}
+
+    decoded_input = post_task_on_mock_client(input_)
+
+    assert {'method': TASK_NAME} == decoded_input
+
+
+def post_task_on_mock_client(input_):
     mock_jwt = MagicMock()
     mock_jwt.decode.return_value = {'identity': FAKE_ID}
-
     mock_requests = MagicMock()
     mock_requests.get.return_value.status_code = 200
     mock_requests.post.return_value.status_code = 200
-
-    input_ = {'method': TASK_NAME}
-
     with patch.multiple('vantage6.client', requests=mock_requests, jwt=mock_jwt):
         client = Client(HOST, PORT)
         client.authenticate(USERNAME, PASSWORD)
@@ -45,5 +49,6 @@ def test_post_task_legacy_method():
 
         decoded_input = base64.b64decode(post_input)
         decoded_input = pickle.loads(decoded_input)
+    return decoded_input
 
-        assert {'method': TASK_NAME} == decoded_input
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,36 @@
+from vantage6.client import Client
+from unittest.mock import patch, MagicMock
+
+# Mock server
+HOST = 'mock_server'
+PORT = 1234
+
+# Mock credentials
+USERNAME = 'vantage6_test'
+PASSWORD = 'secretpassword'
+FAKE_ID = 1
+
+TASK_NAME = 'test-task'
+TASK_IMAGE = 'mock-image'
+COLLABORATION_ID = 1
+ORGANIZATION_IDS = [1]
+
+
+def test_post_task():
+    mock_jwt = MagicMock()
+    mock_jwt.decode.return_value = {'identity': FAKE_ID}
+
+    mock_requests = MagicMock()
+    mock_requests.get.return_value.status_code = 200
+    mock_requests.post.return_value.status_code = 200
+
+    input_ = {'method': TASK_NAME}
+
+    with patch.multiple('vantage6.client', requests=mock_requests, jwt=mock_jwt):
+        client = Client(HOST, PORT)
+        client.authenticate(USERNAME, PASSWORD)
+        client.setup_encryption(None, disabled=True)
+
+        client.post_task(name=TASK_NAME, image=TASK_IMAGE, collaboration_id=COLLABORATION_ID,
+                         organization_ids=ORGANIZATION_IDS, input_=input_)
+        pass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,17 +17,32 @@ TASK_NAME = 'test-task'
 TASK_IMAGE = 'mock-image'
 COLLABORATION_ID = 1
 ORGANIZATION_IDS = [1]
+SAMPLE_INPUT = {'method': 'test-task'}
 
 
 def test_post_task_legacy_method():
-    input_ = {'method': TASK_NAME}
+    post_input = post_task_on_mock_client(SAMPLE_INPUT, 'legacy')
+    decoded_input = base64.b64decode(post_input)
+    decoded_input = pickle.loads(decoded_input)
+    assert {'method': 'test-task'} == decoded_input
 
-    decoded_input = post_task_on_mock_client(input_)
 
-    assert {'method': TASK_NAME} == decoded_input
+def test_post_json_task():
+    post_input = post_task_on_mock_client(SAMPLE_INPUT, 'json')
+    decoded_input = base64.b64decode(post_input)
+    assert b'json.{"method": "test-task"}' == decoded_input
 
 
-def post_task_on_mock_client(input_):
+def test_post_pickle_task():
+    post_input = post_task_on_mock_client(SAMPLE_INPUT, 'pickle')
+    decoded_input = base64.b64decode(post_input)
+
+    assert b'pickle.' == decoded_input[0:7]
+
+    assert {'method': 'test-task'} == pickle.loads(decoded_input[7:])
+
+
+def post_task_on_mock_client(input_, serialization: str):
     mock_jwt = MagicMock()
     mock_jwt.decode.return_value = {'identity': FAKE_ID}
     mock_requests = MagicMock()
@@ -39,7 +54,7 @@ def post_task_on_mock_client(input_):
         client.setup_encryption(None)
 
         client.post_task(name=TASK_NAME, image=TASK_IMAGE, collaboration_id=COLLABORATION_ID,
-                         organization_ids=ORGANIZATION_IDS, input_=input_)
+                         organization_ids=ORGANIZATION_IDS, input_=input_, data_format=serialization)
 
         # In a request.post call, json is provided with the keyword argument 'json'
         # call_args provides a tuple with positional arguments followed by a dict with positional arguments
@@ -47,8 +62,4 @@ def post_task_on_mock_client(input_):
 
         post_input = post_content['organizations'][0]['input']
 
-        decoded_input = base64.b64decode(post_input)
-        decoded_input = pickle.loads(decoded_input)
-    return decoded_input
-
-
+    return post_input

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,18 +1,17 @@
-from unittest import TestCase
-
-from vantage6.client import Client
-from unittest.mock import patch, MagicMock
 import base64
 import pickle
-import io
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from vantage6.client import Client
 
 # Mock server
 HOST = 'mock_server'
 PORT = 1234
 
 # Mock credentials
-USERNAME = 'vantage6_test'
-PASSWORD = 'secretpassword'
+FAKE_USERNAME = 'vantage6_test'
+FAKE_PASSWORD = 'secretpassword'
 FAKE_ID = 1
 
 TASK_NAME = 'test-task'
@@ -52,7 +51,7 @@ class TestClient(TestCase):
         mock_requests.post.return_value.status_code = 200
         with patch.multiple('vantage6.client', requests=mock_requests, jwt=mock_jwt):
             client = Client(HOST, PORT)
-            client.authenticate(USERNAME, PASSWORD)
+            client.authenticate(FAKE_USERNAME, FAKE_PASSWORD)
             client.setup_encryption(None)
 
             client.post_task(name=TASK_NAME, image=TASK_IMAGE, collaboration_id=COLLABORATION_ID,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,5 @@
+from unittest import TestCase
+
 from vantage6.client import Client
 from unittest.mock import patch, MagicMock
 import base64
@@ -20,46 +22,46 @@ ORGANIZATION_IDS = [1]
 SAMPLE_INPUT = {'method': 'test-task'}
 
 
-def test_post_task_legacy_method():
-    post_input = post_task_on_mock_client(SAMPLE_INPUT, 'legacy')
-    decoded_input = base64.b64decode(post_input)
-    decoded_input = pickle.loads(decoded_input)
-    assert {'method': 'test-task'} == decoded_input
+class TestClient(TestCase):
 
+    def test_post_task_legacy_method(self):
+        post_input = TestClient.post_task_on_mock_client(SAMPLE_INPUT, 'legacy')
+        decoded_input = base64.b64decode(post_input)
+        decoded_input = pickle.loads(decoded_input)
+        assert {'method': 'test-task'} == decoded_input
 
-def test_post_json_task():
-    post_input = post_task_on_mock_client(SAMPLE_INPUT, 'json')
-    decoded_input = base64.b64decode(post_input)
-    assert b'json.{"method": "test-task"}' == decoded_input
+    def test_post_json_task(self):
+        post_input = TestClient.post_task_on_mock_client(SAMPLE_INPUT, 'json')
+        decoded_input = base64.b64decode(post_input)
+        assert b'json.{"method": "test-task"}' == decoded_input
 
+    def test_post_pickle_task(self):
+        post_input = TestClient.post_task_on_mock_client(SAMPLE_INPUT, 'pickle')
+        decoded_input = base64.b64decode(post_input)
 
-def test_post_pickle_task():
-    post_input = post_task_on_mock_client(SAMPLE_INPUT, 'pickle')
-    decoded_input = base64.b64decode(post_input)
+        assert b'pickle.' == decoded_input[0:7]
 
-    assert b'pickle.' == decoded_input[0:7]
+        assert {'method': 'test-task'} == pickle.loads(decoded_input[7:])
 
-    assert {'method': 'test-task'} == pickle.loads(decoded_input[7:])
+    @staticmethod
+    def post_task_on_mock_client(input_, serialization: str):
+        mock_jwt = MagicMock()
+        mock_jwt.decode.return_value = {'identity': FAKE_ID}
+        mock_requests = MagicMock()
+        mock_requests.get.return_value.status_code = 200
+        mock_requests.post.return_value.status_code = 200
+        with patch.multiple('vantage6.client', requests=mock_requests, jwt=mock_jwt):
+            client = Client(HOST, PORT)
+            client.authenticate(USERNAME, PASSWORD)
+            client.setup_encryption(None)
 
+            client.post_task(name=TASK_NAME, image=TASK_IMAGE, collaboration_id=COLLABORATION_ID,
+                             organization_ids=ORGANIZATION_IDS, input_=input_, data_format=serialization)
 
-def post_task_on_mock_client(input_, serialization: str):
-    mock_jwt = MagicMock()
-    mock_jwt.decode.return_value = {'identity': FAKE_ID}
-    mock_requests = MagicMock()
-    mock_requests.get.return_value.status_code = 200
-    mock_requests.post.return_value.status_code = 200
-    with patch.multiple('vantage6.client', requests=mock_requests, jwt=mock_jwt):
-        client = Client(HOST, PORT)
-        client.authenticate(USERNAME, PASSWORD)
-        client.setup_encryption(None)
+            # In a request.post call, json is provided with the keyword argument 'json'
+            # call_args provides a tuple with positional arguments followed by a dict with positional arguments
+            post_content = mock_requests.post.call_args[1]['json']
 
-        client.post_task(name=TASK_NAME, image=TASK_IMAGE, collaboration_id=COLLABORATION_ID,
-                         organization_ids=ORGANIZATION_IDS, input_=input_, data_format=serialization)
+            post_input = post_content['organizations'][0]['input']
 
-        # In a request.post call, json is provided with the keyword argument 'json'
-        # call_args provides a tuple with positional arguments followed by a dict with positional arguments
-        post_content = mock_requests.post.call_args[1]['json']
-
-        post_input = post_content['organizations'][0]['input']
-
-    return post_input
+        return post_input

--- a/vantage6/client/__init__.py
+++ b/vantage6/client/__init__.py
@@ -301,7 +301,7 @@ class ClientBase(object):
         self._access_token = response.json()["access_token"]
 
     def post_task(self, name: str, image: str, collaboration_id: int,
-                  input_: bytes = b'', description='',
+                  input_='', description='',
                   organization_ids: list = None) -> dict:
         """ Post a new task at the server.
 

--- a/vantage6/client/__init__.py
+++ b/vantage6/client/__init__.py
@@ -4,14 +4,18 @@ Server IO
 This module is an interface to the central server.
 """
 import logging
-import requests
-import jwt
-import typing
 import pickle
+import typing
 
+import jwt
+import requests
+
+from vantage6.client import serialization
 from vantage6.client.encryption import CryptorBase, RSACryptor, DummyCryptor
 
 module_name = __name__.split('.')[1]
+
+LEGACY = 'legacy'
 
 
 class ServerInfo(typing.NamedTuple):
@@ -302,7 +306,8 @@ class ClientBase(object):
 
     def post_task(self, name: str, image: str, collaboration_id: int,
                   input_='', description='',
-                  organization_ids: list = None) -> dict:
+                  organization_ids: list = None,
+                  data_format=LEGACY) -> dict:
         """ Post a new task at the server.
 
             It will also encrypt `input_` for each receiving
@@ -316,13 +321,19 @@ class ClientBase(object):
             :param description: human readable description of the task
             :param organization_ids: id's of the organizations that need
                 to execute the task
+            :param data_format: Type of data format to use to send and receive data.
+                    possible values: 'json', 'pickle', 'legacy'. 'legacy' will use pickle serialization. Default is
+                    'legacy'.
         """
         assert self.cryptor, "Encryption has not yet been setup!"
 
         if organization_ids is None:
             organization_ids = []
 
-        serialized_input = pickle.dumps(input_)
+        if data_format == LEGACY:
+            serialized_input = pickle.dumps(input_)
+        else:
+            serialized_input = data_format.encode() + b'.' + serialization.serialize(input_, data_format)
 
         organization_json_list = []
         for org_id in organization_ids:
@@ -332,8 +343,7 @@ class ClientBase(object):
 
             organization_json_list.append({
                 "id": org_id,
-                "input": self.cryptor.encrypt_bytes_to_str(serialized_input,
-                                                           pub_key)
+                "input": self.cryptor.encrypt_bytes_to_str(serialized_input, pub_key)
             })
 
         return self.request('task', method='post', json={

--- a/vantage6/client/__init__.py
+++ b/vantage6/client/__init__.py
@@ -333,6 +333,8 @@ class ClientBase(object):
         if data_format == LEGACY:
             serialized_input = pickle.dumps(input_)
         else:
+            # Data will be serialized to bytes in the specified data format.
+            # It will be prepended with 'DATA_FORMAT.' in unicode.
             serialized_input = data_format.encode() + b'.' + serialization.serialize(input_, data_format)
 
         organization_json_list = []

--- a/vantage6/client/serialization.py
+++ b/vantage6/client/serialization.py
@@ -1,0 +1,45 @@
+import json
+import pickle
+
+_serializers = {}
+
+
+def serialize(data, data_format):
+    """
+    Lookup data_format in serializer mapping and return the associated
+    :param data: the data to be serialized
+    :param data_format:
+    :return:
+    """
+    try:
+        return _serializers[data_format.lower()](data)
+    except KeyError as e:
+        raise Exception(f'Serialization of {data_format} has not been implemented.')
+
+
+def serializer(data_format):
+    """
+    Register function as serializer by adding it to the `_serializers` map with key `data_format`.
+
+    :param data_format:
+    :return:
+    """
+
+    def decorator_serializer(func):
+        # Register deserialization function
+        _serializers[data_format] = func
+
+        # Return function without modifications so it can also be run without retrieving it from `_serializers`.
+        return func
+
+    return decorator_serializer
+
+
+@serializer('json')
+def serialize_json(file):
+    return json.dump(file)
+
+
+@serializer('pickle')
+def serialize_pickle(file):
+    return pickle.dump(file)

--- a/vantage6/client/serialization.py
+++ b/vantage6/client/serialization.py
@@ -4,12 +4,12 @@ import pickle
 _serializers = {}
 
 
-def serialize(data, data_format):
+def serialize(data, data_format) -> bytes:
     """
-    Lookup data_format in serializer mapping and return the associated
+    Serialize data using the specified format
     :param data: the data to be serialized
-    :param data_format:
-    :return:
+    :param data_format: the desired data format. Valid options are 'json', 'pickle'.
+    :return: a bytes-like object in the specified serialization format
     """
     try:
         return _serializers[data_format.lower()](data)
@@ -36,10 +36,10 @@ def serializer(data_format):
 
 
 @serializer('json')
-def serialize_json(file):
-    return json.dump(file)
+def serialize_json(file) -> bytes:
+    return json.dumps(file).encode()
 
 
 @serializer('pickle')
-def serialize_pickle(file):
-    return pickle.dump(file)
+def serialize_pickle(file) -> bytes:
+    return pickle.dumps(file)

--- a/vantage6/client/serialization.py
+++ b/vantage6/client/serialization.py
@@ -13,7 +13,7 @@ def serialize(data, data_format) -> bytes:
     """
     try:
         return _serializers[data_format.lower()](data)
-    except KeyError as e:
+    except KeyError:
         raise Exception(f'Serialization of {data_format} has not been implemented.')
 
 


### PR DESCRIPTION
Implemented cross language serialization on the client side. This should now work with the newly implemented deserialization in the python wrapper.

When no data format is specified the old method will be used.

I also created unittests for the post_task method. I might set up travis to run the tests in a different PR.

I cleaned up the imports and formatting in the first commit.