### PR TITLE
Fix for updating country field in organization

### DIFF
--- a/vantage6/client/__init__.py
+++ b/vantage6/client/__init__.py
@@ -943,7 +943,7 @@ class UserClient(ClientBase):
                     'address1': address1,
                     'address2': address2,
                     'zipcode': zipcode,
-                    'county': country,
+                    'country': country,
                     'domain': domain,
                     'public_key': public_key
                 }


### PR DESCRIPTION
In updating the organization table, the country field was misspelled in the vantage python client. This is corrected here.
Also verified that this solves the problem by calling the relevant function before and after the change and observing the country changes in the database.